### PR TITLE
Bump version of docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.69-bullseye as builder
+FROM rust:1.70-bullseye as builder
 WORKDIR /usr/src/timezoned_rs
 COPY . .
 RUN cargo install --path .


### PR DESCRIPTION
NOTE: I'm very new to rust and don't have a lot of experience.

First off, I just wanted to say thanks for creating this awesome project. I just finished assembling my portal calendar yesterday, and I'm very excited to start using it!

I wanted to self-host this and when I tried building the container I ran across this error:

```bash
$ docker build -t timezoned_rs .
...
43.18 error: failed to compile `timezoned_rs v0.1.0 (/usr/src/timezoned_rs)`, intermediate artifacts can be found at `/usr/src/timezoned_rs/target`
43.18
43.18 Caused by:
43.18   package `mio v1.0.3` cannot be built because it requires rustc 1.70 or newer, while the currently active rustc version is 1.69.0
43.18   Either upgrade to rustc 1.70 or newer, or use
43.18   cargo update -p mio@1.0.3 --precise ver
43.18   where `ver` is the latest version of `mio` supporting rustc 1.69.0
```

Building it on another machine, I got the same error for the `tokio` package. Again, I'm very new to rust, but changing the base image to 1.70 let me build the image without any errors. I'm hoping this PR will help anyone else who tries building this in the future.